### PR TITLE
feat: add EdDSA (Ed25519) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A security-first JWT CLI for developers and platform engineers for inspecting an
 
 - **Flexible Input (The Resolver Pattern):** Read tokens or keys from direct strings, local files (`@path`), or `stdin` (`-`).
 - **Unified Inspection & Verification:** Always decodes and displays token content, with automatic cryptographic validation if a key is provided.
-- **Signature Verification:** Supports HMAC (HS256/384/512), RSA (RS256/384/512), and ECDSA (ES256/384/512).
+- **Signature Verification:** Supports HMAC (HS256/384/512), RSA (RS256/384/512), ECDSA (ES256/384/512), and EdDSA (Ed25519).
 - **JWKS Integration:** Fetch and validate against local or remote JSON Web Key Sets (JWKS).
 - **Keycloak Integration:** Easily fetch OIDC discovery information or introspect tokens from Keycloak realms.
 - **Smart Output:** Default machine-readable **JSON** output, with a beautiful colorized **Table** view for humans.
@@ -66,7 +66,7 @@ Cryptographically validate the signature and time-based claims by providing a ve
 # Using a symmetric secret
 jwt-tool inspect <TOKEN> --secret "my-super-secret"
 
-# Using a Public Key (RSA/ECDSA)
+# Using a Public Key (RSA/ECDSA/EdDSA)
 jwt-tool inspect <TOKEN> --pem @public_key.pem
 
 # Using a remote JWKS endpoint
@@ -86,6 +86,9 @@ jwt-tool keygen
 # Generate ECDSA P-384 and save to files
 jwt-tool keygen -a ecdsa -c P384 -f mykey
 # Results in 'mykey' (private) and 'mykey.pub' (public)
+
+# Generate EdDSA (Ed25519) and save to files
+jwt-tool keygen -a eddsa -f mykey-ed
 ```
 
 ### 4. Keycloak Integration
@@ -174,13 +177,13 @@ When verification is requested, `jwt-tool` adds an `x-validation` field to the J
 ### `inspect` Flags
 - *Usage: `jwt-tool inspect [token|-|@file] [flags]`*
 - `--secret <string>`: Symmetric secret for HMAC.
-- `--pem <path>`: Path to RSA/ECDSA public key file (`@path`).
+- `--pem <path>`: Path to RSA/ECDSA/EdDSA public key file (`@path`).
 - `--jwks <uri|path>`: Path or URL to a JWKS.
 - `--leeway <duration>`: Clock skew tolerance (e.g., `1m`, `30s`).
 - *Aliases: `decode`, `verify`*
 
 ### `keygen` Flags
-- `-a, --alg <string>`: Algorithm: `rsa` (default) or `ecdsa`.
+- `-a, --alg <string>`: Algorithm: `rsa` (default), `ecdsa`, or `eddsa`.
 - `-b, --bits <int>`: RSA bit size: `2048`, `3072`, `4096`.
 - `-c, --curve <string>`: ECDSA curve: `P256`, `P384`, `P521`.
 - `-f, --file <path>`: Save to file (creates `.pub` for public key). **If omitted, prints both private and public keys to stdout.**

--- a/cmd/jwt-tool/main.go
+++ b/cmd/jwt-tool/main.go
@@ -64,7 +64,7 @@ If a verification key is provided (--secret, --pem, or --jwks), it also validate
 	// Add verification flags to both rootCmd and inspectCmd
 	for _, cmd := range []*cobra.Command{rootCmd, inspectCmd} {
 		cmd.Flags().StringVar(&secret, "secret", "", "Symmetric secret for HMAC verification")
-		cmd.Flags().StringVar(&pemPath, "pem", "", "Path to RSA/ECDSA public key PEM file (@path)")
+		cmd.Flags().StringVar(&pemPath, "pem", "", "Path to RSA/ECDSA/EdDSA public key PEM file (@path)")
 		cmd.Flags().StringVar(&jwksPath, "jwks", "", "Path or URL to JWKS")
 		cmd.Flags().StringVar(&leeway, "leeway", "0s", "Clock skew tolerance (e.g. 60s)")
 	}
@@ -201,11 +201,11 @@ If a verification key is provided (--secret, --pem, or --jwks), it also validate
 	keycloakCmd.AddCommand(keycloakInfoCmd, keycloakIntrospectCmd, keycloakLoginCmd)
 	keygenCmd := &cobra.Command{
 		Use:   "keygen",
-		Short: "Generate a new asymmetric key pair (RSA or ECDSA) in PEM format",
+		Short: "Generate a new asymmetric key pair (RSA, ECDSA, or EdDSA) in PEM format",
 		Run:   runKeygen,
 	}
 
-	keygenCmd.Flags().StringVarP(&kgAlg, "alg", "a", "rsa", "Algorithm: rsa or ecdsa")
+	keygenCmd.Flags().StringVarP(&kgAlg, "alg", "a", "rsa", "Algorithm: rsa, ecdsa, or eddsa")
 	keygenCmd.Flags().IntVarP(&kgBits, "bits", "b", 2048, "RSA bit size: 2048, 3072, 4096")
 	keygenCmd.Flags().StringVarP(&kgCurve, "curve", "c", "P256", "ECDSA curve: P256, P384, P521")
 	keygenCmd.Flags().StringVarP(&kgFile, "file", "f", "", "Save to file (e.g. 'id_rsa' creates 'id_rsa' and 'id_rsa.pub')")
@@ -248,7 +248,7 @@ func runInspect(cmd *cobra.Command, args []string) {
 	// Step 2: Attempt verification if keys are provided
 	if secret != "" || pemPath != "" || jwksPath != "" {
 		opts := verifier.VerifyOptions{
-			Algorithms: []string{"HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512"},
+			Algorithms: []string{"HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "EdDSA"},
 		}
 
 		if secret != "" {
@@ -264,16 +264,16 @@ func runInspect(cmd *cobra.Command, args []string) {
 			if err != nil {
 				exitWithError("could not resolve PEM path", err)
 			}
-			pub, err := jwt.ParseRSAPublicKeyFromPEM(p)
-			if err != nil {
-				// Try ECDSA if RSA fails
-				pubEC, errEC := jwt.ParseECPublicKeyFromPEM(p)
-				if errEC != nil {
-					exitWithError("could not parse PEM", fmt.Errorf("tried RSA and ECDSA: %v", err))
-				}
-				opts.PublicKey = pubEC
-			} else {
+
+			// Try to parse as RSA, then ECDSA, then EdDSA
+			if pub, err := jwt.ParseRSAPublicKeyFromPEM(p); err == nil {
 				opts.PublicKey = pub
+			} else if pub, err := jwt.ParseECPublicKeyFromPEM(p); err == nil {
+				opts.PublicKey = pub
+			} else if pub, err := jwt.ParseEdPublicKeyFromPEM(p); err == nil {
+				opts.PublicKey = pub
+			} else {
+				exitWithError("could not parse PEM", fmt.Errorf("tried RSA, ECDSA, and EdDSA public keys"))
 			}
 		}
 
@@ -331,6 +331,8 @@ func runKeygen(cmd *cobra.Command, args []string) {
 		kp, err = keygen.GenerateRSA(kgBits)
 	case "ecdsa":
 		kp, err = keygen.GenerateECDSA(kgCurve)
+	case "eddsa":
+		kp, err = keygen.GenerateEdDSA()
 	default:
 		exitWithError("unsupported algorithm", fmt.Errorf("%s", kgAlg))
 	}

--- a/internal/keygen/keygen.go
+++ b/internal/keygen/keygen.go
@@ -2,6 +2,7 @@ package keygen
 
 import (
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
@@ -14,6 +15,39 @@ import (
 type KeyPair struct {
 	PrivatePEM []byte
 	PublicPEM  []byte
+}
+
+// GenerateEdDSA generates a new Ed25519 key pair.
+func GenerateEdDSA() (*KeyPair, error) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("could not generate EdDSA key: %w", err)
+	}
+
+	// Encode Private Key (PKCS#8)
+	privBytes, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal private key: %w", err)
+	}
+	privBlock := &pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: privBytes,
+	}
+
+	// Encode Public Key (PKIX)
+	pubBytes, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal public key: %w", err)
+	}
+	pubBlock := &pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: pubBytes,
+	}
+
+	return &KeyPair{
+		PrivatePEM: pem.EncodeToMemory(privBlock),
+		PublicPEM:  pem.EncodeToMemory(pubBlock),
+	}, nil
 }
 
 // GenerateRSA generates a new RSA key pair.

--- a/internal/keygen/keygen_test.go
+++ b/internal/keygen/keygen_test.go
@@ -66,6 +66,33 @@ func TestGenerateECDSA(t *testing.T) {
 	}
 }
 
+func TestGenerateEdDSA(t *testing.T) {
+	kp, err := GenerateEdDSA()
+	if err != nil {
+		t.Fatalf("failed to generate EdDSA key: %v", err)
+	}
+
+	// Verify Private Key
+	block, _ := pem.Decode(kp.PrivatePEM)
+	if block == nil || block.Type != "PRIVATE KEY" {
+		t.Errorf("invalid private key PEM")
+	}
+	_, err = x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		t.Errorf("failed to parse PKCS8 private key: %v", err)
+	}
+
+	// Verify Public Key
+	block, _ = pem.Decode(kp.PublicPEM)
+	if block == nil || block.Type != "PUBLIC KEY" {
+		t.Errorf("invalid public key PEM")
+	}
+	_, err = x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		t.Errorf("failed to parse PKIX public key: %v", err)
+	}
+}
+
 func TestGenerateECDSA_InvalidCurve(t *testing.T) {
 	_, err := GenerateECDSA("invalid")
 	if err == nil {

--- a/internal/verifier/verifier.go
+++ b/internal/verifier/verifier.go
@@ -35,7 +35,7 @@ func Verify(tokenStr string, opts VerifyOptions) (*models.TokenInfo, error) {
 				return nil, fmt.Errorf("missing secret for HMAC algorithm %s", token.Method.Alg())
 			}
 			return opts.Secret, nil
-		case "RS256", "RS384", "RS512", "PS256", "PS384", "PS512", "ES256", "ES384", "ES512":
+		case "RS256", "RS384", "RS512", "PS256", "PS384", "PS512", "ES256", "ES384", "ES512", "EdDSA":
 			if opts.PublicKey != nil {
 				return opts.PublicKey, nil
 			}

--- a/internal/verifier/verifier_test.go
+++ b/internal/verifier/verifier_test.go
@@ -1,6 +1,8 @@
 package verifier
 
 import (
+	"crypto/ed25519"
+	"crypto/rand"
 	"testing"
 	"time"
 
@@ -9,6 +11,35 @@ import (
 
 func TestVerify(t *testing.T) {
 	secret := []byte("my-secret")
+
+	t.Run("Valid EdDSA token", func(t *testing.T) {
+		pub, priv, err := ed25519.GenerateKey(rand.Reader)
+		if err != nil {
+			t.Fatalf("failed to generate EdDSA key: %v", err)
+		}
+
+		token := jwt.NewWithClaims(jwt.SigningMethodEdDSA, jwt.MapClaims{
+			"sub": "1234567890",
+			"exp": time.Now().Add(time.Hour).Unix(),
+		})
+		tokenStr, err := token.SignedString(priv)
+		if err != nil {
+			t.Fatalf("failed to sign token: %v", err)
+		}
+
+		opts := VerifyOptions{
+			PublicKey:  pub,
+			Algorithms: []string{"EdDSA"},
+		}
+
+		info, err := Verify(tokenStr, opts)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if info.Payload["sub"] != "1234567890" {
+			t.Errorf("expected sub 1234567890, got %v", info.Payload["sub"])
+		}
+	})
 
 	t.Run("Valid HMAC token", func(t *testing.T) {
 		token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{


### PR DESCRIPTION
Implement EdDSA (Ed25519) support for JWT verification and key generation.

Changes included:
- **Verification:** Updated `internal/verifier/verifier.go` to include `EdDSA` in the supported algorithms.
- **Key Generation:** Implemented `GenerateEdDSA` in `internal/keygen/keygen.go` for Ed25519 key pairs.
- **CLI:** Updated `cmd/jwt-tool/main.go` to support EdDSA verification, PEM parsing, and key generation flags.
- **Documentation:** Updated `README.md` with EdDSA details.
- **Tests:** Added unit tests in `internal/keygen/keygen_test.go` and `internal/verifier/verifier_test.go`.

Note: Support for Ed448 was skipped as it is not natively supported by `github.com/golang-jwt/jwt/v5`.

Closes #11